### PR TITLE
Bump streamlit version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-streamlit==0.69
+streamlit==0.81


### PR DESCRIPTION
PR #7 was merged without us realizing that removing the beta_ prefix
from set_page_config wasn't compatible with the version of streamlit
that the demo app is pinned to in requirements.txt (st.set_page_config
was still in beta in version 0.69).

This PR bumps the version number up to the most recent version, which
is probably preferable to reverting #7 since it makes the app work
again in Streamlit sharing while also making it compatible with more
recent versions of streamlit that people may be using when they run the
app locally.

I tested this locally by running the app with both version 0.69 and 0.81
and couldn't see any difference between the two.