### PR TITLE
Replace the local filepath to uber data with remote GitHub raw URL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit==1.11.1
+streamlit==1.20.0
 pydeck==0.7.1
 protobuf==3.19.5

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -26,7 +26,7 @@ st.set_page_config(layout="wide", page_title="NYC Ridesharing Demo", page_icon="
 
 
 # LOAD DATA ONCE
-@st.experimental_singleton
+@st.cache_resource
 def load_data():
     data = pd.read_csv(
         "https://github.com/streamlit/demo-uber-nyc-pickups/raw/main/uber-raw-data-sep14.csv.gz",
@@ -74,19 +74,19 @@ def map(data, lat, lon, zoom):
 
 
 # FILTER DATA FOR A SPECIFIC HOUR, CACHE
-@st.experimental_memo
+@st.cache_data
 def filterdata(df, hour_selected):
     return df[df["date/time"].dt.hour == hour_selected]
 
 
 # CALCULATE MIDPOINT FOR GIVEN SET OF DATA
-@st.experimental_memo
+@st.cache_data
 def mpoint(lat, lon):
     return (np.average(lat), np.average(lon))
 
 
 # FILTER DATA BY HOUR
-@st.experimental_memo
+@st.cache_data
 def histdata(df, hr):
     filtered = data[
         (df["date/time"].dt.hour >= hr) & (df["date/time"].dt.hour < (hr + 1))

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -24,11 +24,12 @@ import streamlit as st
 # SETTING PAGE CONFIG TO WIDE MODE AND ADDING A TITLE AND FAVICON
 st.set_page_config(layout="wide", page_title="NYC Ridesharing Demo", page_icon=":taxi:")
 
+
 # LOAD DATA ONCE
 @st.experimental_singleton
 def load_data():
     data = pd.read_csv(
-        "uber-raw-data-sep14.csv.gz",
+        "https://github.com/streamlit/demo-uber-nyc-pickups/raw/main/uber-raw-data-sep14.csv.gz",
         nrows=100000,  # approx. 10% of data
         names=[
             "date/time",
@@ -112,6 +113,7 @@ if not st.session_state.get("url_synced", False):
         st.session_state["url_synced"] = True
     except KeyError:
         pass
+
 
 # IF THE SLIDER CHANGES, UPDATE THE QUERY PARAM
 def update_query_params():

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -15,6 +15,8 @@
 
 """An example of showing geographic data."""
 
+import os
+
 import altair as alt
 import numpy as np
 import pandas as pd
@@ -28,8 +30,12 @@ st.set_page_config(layout="wide", page_title="NYC Ridesharing Demo", page_icon="
 # LOAD DATA ONCE
 @st.cache_resource
 def load_data():
+    path = "uber-raw-data-sep14.csv.gz"
+    if not os.path.isfile(path):
+        path = f"https://github.com/streamlit/demo-uber-nyc-pickups/raw/main/{path}"
+
     data = pd.read_csv(
-        "https://github.com/streamlit/demo-uber-nyc-pickups/raw/main/uber-raw-data-sep14.csv.gz",
+        path,
         nrows=100000,  # approx. 10% of data
         names=[
             "date/time",


### PR DESCRIPTION
## Context

Fixes #28.
The [instructions](https://github.com/streamlit/demo-uber-nyc-pickups#run-this-demo-locally) to run this demo locally do not work:

```sh
pip install --upgrade streamlit
streamlit run https://raw.githubusercontent.com/streamlit/demo-uber-nyc-pickups/main/streamlit_app.py
```

Running the above results in a:
```
[FileNotFoundError](https://github.com/streamlit/demo-uber-nyc-pickups/blob/main/streamlit_app.py#L30-L43):

[Errno 2] No such file or directory: 'uber-raw-data-sep14.csv.gz'
```

because `streamlit run` downloads the `.py` file and does not clone the repo. Within the `.py` file, Pandas tries to load data from a local filepath:

https://github.com/streamlit/demo-uber-nyc-pickups/blob/01a4628634f6f0f15a2738cc4500660c4acddb27/streamlit_app.py#L30-L43

As the local filepath does not exist, it throws the FileNotFoundError.  In addition to the README, these instructions are also found in our docs: [Main concepts](https://docs.streamlit.io/library/get-started/main-concepts), [Create an app](https://docs.streamlit.io/library/get-started/create-an-app#create-your-first-app). We've had [reports](https://snowflake.slack.com/archives/C039XQ62PB7/p1678487016711679) of users running into this bug by following the instructions in our docs.

## Description of changes

- Replaces the local file path to `pd.read_csv` from `uber-raw-data-sep14.csv.gz` to a remote URL https://github.com/streamlit/demo-uber-nyc-pickups/raw/main/uber-raw-data-sep14.csv.gz
- Bumps Streamlit from version 1.11.1 to 1.20.0
- Replaces memo+singleton with cache_resource+cache_data